### PR TITLE
dune: increased rucio-server memory from 2Gi to 3Gi

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ At Fermilab, we use centrally managed PostgreSQL databases.
   * `hostcert.pem`: Host server certificate
   * `hostkey.pem`: Host server key
   * `ca.pem`: CA Certificate bundle
-  * `db-connstr`: Database Connection String; in the format of `postgresql://<user>:<password>@<database-url>:<database-port>/<rucio-db-name>`
+  * `db-connstr`: Database Connection String; in the format of `postgresql+psycopg://<user>:<password>@<database-url>:<database-port>/<rucio-db-name>`
+    * Using only `postgresql://` defaults to using `psycopg2` in SQLAlchemy, which is not installed in the Rucio containers. Rucio containers are now installing `psycopg`, which is actuall `psycopg3`. Thus, we use `posgtresql+psycopg://` to switch to the proper `psycopg`.
+    * See: https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg
   * *Note:* These secrets should be stored onto a secrets management service (i.e. Vault), then pulled when apply configurations
 * (Optional) Custom Policy Package
   * `__init__.py`

--- a/overlays/dune/rucio/helm-rucio-server.yaml
+++ b/overlays/dune/rucio/helm-rucio-server.yaml
@@ -127,10 +127,10 @@ spec:
           resources:
             limits:
               cpu: 1000m
-              memory: 2000Mi
+              memory: 3000Mi
             requests:
               cpu: 700m
-              memory: 2000Mi
+              memory: 3000Mi
           volumeMounts:
           - name: config
             mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/overlays/dune/rucio/values-rucio-server.yaml
+++ b/overlays/dune/rucio/values-rucio-server.yaml
@@ -420,10 +420,10 @@ config:
 
 serverResources:
   limits:
-    memory: "2000Mi"
+    memory: "3000Mi"
     cpu: "1000m"
   requests:
-    memory: "2000Mi"
+    memory: "3000Mi"
     cpu: "700m"
 
 nodeSelector: {}


### PR DESCRIPTION
Updated README to include information about db connection string so that SQLAlchemy will use psycopg3 (psycopg) instead of psycopg2