### PR TITLE
dune: Enable WSGI listen backlog, increase memory, timeout for rucio-server

### DIFF
--- a/overlays/dune-int/rucio/etc/rucio-server.conf.j2
+++ b/overlays/dune-int/rucio/etc/rucio-server.conf.j2
@@ -1,0 +1,136 @@
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
+LoadModule ssl_module /usr/lib64/httpd/modules/mod_ssl.so
+{% set listen_port = 443 %}
+{% else %}
+{% set listen_port = 80 %}
+{% endif %}
+{% if RUCIO_HTTPD_GRID_SITE_ENABLED | default('False') == 'True' %}
+LoadModule gridsite_module /usr/lib64/httpd/modules/mod_gridsite.so
+{% endif %}
+LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule wsgi_module /usr/lib64/httpd/modules/mod_wsgi_python3.so
+Listen {{ listen_port }}
+Header set X-Rucio-Host "%{HTTP_HOST}e"
+RequestHeader add X-Rucio-RequestId "%{UNIQUE_ID}e"
+
+{% if RUCIO_LOG_FORMAT is defined %}
+LogFormat "{{ RUCIO_LOG_FORMAT }}" combinedrucio
+{% else %}
+LogFormat "%h\t%t\t%{X-Rucio-Forwarded-For}i\t%T\t%D\t\"%{X-Rucio-Auth-Token}i\"\t%{X-Rucio-RequestId}i\t%{X-Rucio-Client-Ref}i\t\"%r\"\t%>s\t%b" combinedrucio
+{% endif %}
+
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule cache_disk_module modules/mod_cache_disk.so
+
+WSGIRestrictEmbedded On
+WSGIDaemonProcess rucio processes={{ RUCIO_WSGI_DAEMON_PROCESSES | default('4') }} threads={{ RUCIO_WSGI_DAEMON_THREADS | default('4') }} listen-backlog=200 display-name=%{GROUP}
+WSGIApplicationGroup rucio
+
+CacheEnable disk /
+CacheRoot /tmp
+
+{% macro common_virtual_host_config(port, enable_ssl, require_x509_auth ) %}
+{% if RUCIO_HOSTNAME is defined %}
+ ServerName {{ RUCIO_HOSTNAME }}:{{ port }}
+{% endif %}
+ ServerAdmin {{ RUCIO_SERVER_ADMIN | default('rucio-admin@cern.ch')}}
+{% if enable_ssl %}
+ SSLEngine on
+ SSLCertificateFile /etc/grid-security/hostcert.pem
+ SSLCertificateKeyFile /etc/grid-security/hostkey.pem
+{% if RUCIO_CA_PATH is defined %}
+ SSLCACertificatePath {{ RUCIO_CA_PATH }}
+ SSLCARevocationPath {{ RUCIO_CA_PATH }}
+ SSLCARevocationCheck {{ RUCIO_CA_REVOCATION_CHECK | default('chain') }}
+{% else %}
+ SSLCACertificateFile /etc/grid-security/ca.pem
+{% endif %}
+ SSLVerifyClient optional_no_ca
+ SSLVerifyDepth 10
+ {% if require_x509_auth %}
+ <Location /auth/x509/webui>
+  SSLVerifyClient optional
+  <LimitExcept OPTIONS>
+   SSLVerifyClient optional
+  </LimitExcept>
+  SSLVerifyDepth 10
+ </Location>
+{% endif %}
+{% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}
+ SSLOptions +StdEnvVars +LegacyDNStringFormat
+{% else %}
+ SSLOptions +StdEnvVars
+{% endif %}
+
+{% if RUCIO_SSL_PROTOCOL is defined %}
+ #AB: SSLv3 disable
+ SSLProtocol              {{ RUCIO_SSL_PROTOCOL }}
+{% else %}
+ SSLProtocol              +TLSv1.2
+{% endif %}
+ #AB: for Security
+ SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
+{% endif %}
+
+ LogLevel {{ RUCIO_LOG_LEVEL | default('info') }}
+
+{% if RUCIO_ENABLE_LOGS|default('False') == 'True' %}
+ CustomLog {{RUCIO_HTTPD_LOG_DIR | default('logs') }}/access_log combinedrucio
+ ErrorLog {{RUCIO_HTTPD_LOG_DIR | default('logs') }}/error_log
+{% else %}
+ CustomLog /dev/stdout combinedrucio
+ ErrorLog /dev/stderr
+{% endif %}
+
+{% if RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE|default('False') == 'True' %}
+ AllowEncodedSlashes NoDecode
+{% elif RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
+ AllowEncodedSlashes on
+{% endif %}
+
+ RewriteEngine on
+ RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)
+ RewriteRule .* - [F]
+{% endmacro %}
+
+<VirtualHost *:{{ listen_port}} >
+{{ common_virtual_host_config(port=listen_port, enable_ssl=RUCIO_ENABLE_SSL|default('False') == 'True', require_x509_auth=true ) }}
+{% if RUCIO_DEFINE_ALIASES|default('False') == 'True' %}
+ Include /opt/rucio/etc/aliases.conf
+{% else %}
+ WSGIScriptAlias / {{ RUCIO_PYTHON_PATH }}/web/rest/flaskapi/v1/main.py process-group=rucio application-group=rucio
+{% endif %}
+
+{% if RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED | default('False') == 'True' %}
+ RemoteIPProxyProtocol On
+ RemoteIPProxyProtocolExceptions 127.0.0.1 ::1 {{ RUCIO_HTTPD_PROXY_PROTOCOL_EXCEPTIONS | default('') }}
+{% endif %}
+
+{% if RUCIO_HTTPD_GRID_SITE_ENABLED | default('False') == 'True' %}
+ <LocationMatch {{ RUCIO_HTTPD_GRID_SITE_LOCATION_MATCH | default('/auth/x509_proxy') }} >
+  GridSiteIndexes {{ RUCIO_HTTPD_GRID_SITE_INDEXES | default('on') }}
+  GridSiteAuth {{ RUCIO_HTTPD_GRID_SITE_AUTH | default('on') }}
+  GridSiteGSIProxyLimit {{ RUCIO_HTTPD_GRID_SITE_GSI_PROXY_LIMIT | default('16') }}
+  GridSiteEnvs {{ RUCIO_HTTPD_GRID_SITE_ENVS | default('on') }}
+  GridSiteACLPath {{ RUCIO_HTTPD_GRID_SITE_ACL_PATH | default('/etc/httpd/gacl') }}
+ </LocationMatch>
+{% endif %}
+</VirtualHost>
+
+{% if RUCIO_METRICS_PORT is defined %}
+Listen {{ RUCIO_METRICS_PORT }}
+<VirtualHost *:{{ RUCIO_METRICS_PORT }} >
+{{ common_virtual_host_config(port=RUCIO_METRICS_PORT, enable_ssl=false) }}
+
+ WSGIScriptAlias /metrics {{ RUCIO_PYTHON_PATH }}/web/rest/metrics.py process-group=rucio application-group=rucio
+</VirtualHost>
+{% endif %}
+
+{% if RUCIO_HEALTH_CHECK_PORT is defined %}
+Listen {{ RUCIO_HEALTH_CHECK_PORT }}
+<VirtualHost *:{{ RUCIO_HEALTH_CHECK_PORT }} >
+{{ common_virtual_host_config(port=RUCIO_HEALTH_CHECK_PORT, enable_ssl=RUCIO_ENABLE_SSL|default('False') == 'True', require_x509_auth=false) }}
+
+ WSGIScriptAlias /ping {{ RUCIO_PYTHON_PATH }}/web/rest/ping.py process-group=rucio application-group=rucio
+</VirtualHost>
+{% endif %}

--- a/overlays/dune-int/rucio/kustomization.yaml
+++ b/overlays/dune-int/rucio/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 patchesStrategicMerge:
 - grid-certificates-patch.yaml
 - patch-webui.yaml
+- patch-server.yaml
 - patch-busybox.yaml
 - patch-service.yaml
 
@@ -24,6 +25,9 @@ configmapGenerator:
 - name: webui-rucio-conf-j2
   files:
   - rucio.conf.j2=etc/rucio.conf.j2
+- name: server-rucio-conf-j2
+  files:
+  - rucio.conf.j2=etc/rucio-server.conf.j2
 
 secretGenerator:
 # Database Connection String

--- a/overlays/dune-int/rucio/patch-server.yaml
+++ b/overlays/dune-int/rucio/patch-server.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-rucio-server
+spec:
+  template:
+    spec:
+      serviceAccountName: useroot
+      volumes:
+        - name: rucio-conf-j2
+          configMap:
+            name: server-rucio-conf-j2
+      containers:
+        - name: rucio-server 
+          volumeMounts:
+            - name: rucio-conf-j2
+              mountPath: /tmp/rucio.conf.j2
+              subPath: rucio.conf.j2

--- a/overlays/dune/rucio/etc/rucio-server.conf.j2
+++ b/overlays/dune/rucio/etc/rucio-server.conf.j2
@@ -1,0 +1,136 @@
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
+LoadModule ssl_module /usr/lib64/httpd/modules/mod_ssl.so
+{% set listen_port = 443 %}
+{% else %}
+{% set listen_port = 80 %}
+{% endif %}
+{% if RUCIO_HTTPD_GRID_SITE_ENABLED | default('False') == 'True' %}
+LoadModule gridsite_module /usr/lib64/httpd/modules/mod_gridsite.so
+{% endif %}
+LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule wsgi_module /usr/lib64/httpd/modules/mod_wsgi_python3.so
+Listen {{ listen_port }}
+Header set X-Rucio-Host "%{HTTP_HOST}e"
+RequestHeader add X-Rucio-RequestId "%{UNIQUE_ID}e"
+
+{% if RUCIO_LOG_FORMAT is defined %}
+LogFormat "{{ RUCIO_LOG_FORMAT }}" combinedrucio
+{% else %}
+LogFormat "%h\t%t\t%{X-Rucio-Forwarded-For}i\t%T\t%D\t\"%{X-Rucio-Auth-Token}i\"\t%{X-Rucio-RequestId}i\t%{X-Rucio-Client-Ref}i\t\"%r\"\t%>s\t%b" combinedrucio
+{% endif %}
+
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule cache_disk_module modules/mod_cache_disk.so
+
+WSGIRestrictEmbedded On
+WSGIDaemonProcess rucio processes={{ RUCIO_WSGI_DAEMON_PROCESSES | default('4') }} threads={{ RUCIO_WSGI_DAEMON_THREADS | default('4') }} listen-backlog=200 display-name=%{GROUP}
+WSGIApplicationGroup rucio
+
+CacheEnable disk /
+CacheRoot /tmp
+
+{% macro common_virtual_host_config(port, enable_ssl, require_x509_auth ) %}
+{% if RUCIO_HOSTNAME is defined %}
+ ServerName {{ RUCIO_HOSTNAME }}:{{ port }}
+{% endif %}
+ ServerAdmin {{ RUCIO_SERVER_ADMIN | default('rucio-admin@cern.ch')}}
+{% if enable_ssl %}
+ SSLEngine on
+ SSLCertificateFile /etc/grid-security/hostcert.pem
+ SSLCertificateKeyFile /etc/grid-security/hostkey.pem
+{% if RUCIO_CA_PATH is defined %}
+ SSLCACertificatePath {{ RUCIO_CA_PATH }}
+ SSLCARevocationPath {{ RUCIO_CA_PATH }}
+ SSLCARevocationCheck {{ RUCIO_CA_REVOCATION_CHECK | default('chain') }}
+{% else %}
+ SSLCACertificateFile /etc/grid-security/ca.pem
+{% endif %}
+ SSLVerifyClient optional_no_ca
+ SSLVerifyDepth 10
+ {% if require_x509_auth %}
+ <Location /auth/x509/webui>
+  SSLVerifyClient optional
+  <LimitExcept OPTIONS>
+   SSLVerifyClient optional
+  </LimitExcept>
+  SSLVerifyDepth 10
+ </Location>
+{% endif %}
+{% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}
+ SSLOptions +StdEnvVars +LegacyDNStringFormat
+{% else %}
+ SSLOptions +StdEnvVars
+{% endif %}
+
+{% if RUCIO_SSL_PROTOCOL is defined %}
+ #AB: SSLv3 disable
+ SSLProtocol              {{ RUCIO_SSL_PROTOCOL }}
+{% else %}
+ SSLProtocol              +TLSv1.2
+{% endif %}
+ #AB: for Security
+ SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
+{% endif %}
+
+ LogLevel {{ RUCIO_LOG_LEVEL | default('info') }}
+
+{% if RUCIO_ENABLE_LOGS|default('False') == 'True' %}
+ CustomLog {{RUCIO_HTTPD_LOG_DIR | default('logs') }}/access_log combinedrucio
+ ErrorLog {{RUCIO_HTTPD_LOG_DIR | default('logs') }}/error_log
+{% else %}
+ CustomLog /dev/stdout combinedrucio
+ ErrorLog /dev/stderr
+{% endif %}
+
+{% if RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE|default('False') == 'True' %}
+ AllowEncodedSlashes NoDecode
+{% elif RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
+ AllowEncodedSlashes on
+{% endif %}
+
+ RewriteEngine on
+ RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)
+ RewriteRule .* - [F]
+{% endmacro %}
+
+<VirtualHost *:{{ listen_port}} >
+{{ common_virtual_host_config(port=listen_port, enable_ssl=RUCIO_ENABLE_SSL|default('False') == 'True', require_x509_auth=true ) }}
+{% if RUCIO_DEFINE_ALIASES|default('False') == 'True' %}
+ Include /opt/rucio/etc/aliases.conf
+{% else %}
+ WSGIScriptAlias / {{ RUCIO_PYTHON_PATH }}/web/rest/flaskapi/v1/main.py process-group=rucio application-group=rucio
+{% endif %}
+
+{% if RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED | default('False') == 'True' %}
+ RemoteIPProxyProtocol On
+ RemoteIPProxyProtocolExceptions 127.0.0.1 ::1 {{ RUCIO_HTTPD_PROXY_PROTOCOL_EXCEPTIONS | default('') }}
+{% endif %}
+
+{% if RUCIO_HTTPD_GRID_SITE_ENABLED | default('False') == 'True' %}
+ <LocationMatch {{ RUCIO_HTTPD_GRID_SITE_LOCATION_MATCH | default('/auth/x509_proxy') }} >
+  GridSiteIndexes {{ RUCIO_HTTPD_GRID_SITE_INDEXES | default('on') }}
+  GridSiteAuth {{ RUCIO_HTTPD_GRID_SITE_AUTH | default('on') }}
+  GridSiteGSIProxyLimit {{ RUCIO_HTTPD_GRID_SITE_GSI_PROXY_LIMIT | default('16') }}
+  GridSiteEnvs {{ RUCIO_HTTPD_GRID_SITE_ENVS | default('on') }}
+  GridSiteACLPath {{ RUCIO_HTTPD_GRID_SITE_ACL_PATH | default('/etc/httpd/gacl') }}
+ </LocationMatch>
+{% endif %}
+</VirtualHost>
+
+{% if RUCIO_METRICS_PORT is defined %}
+Listen {{ RUCIO_METRICS_PORT }}
+<VirtualHost *:{{ RUCIO_METRICS_PORT }} >
+{{ common_virtual_host_config(port=RUCIO_METRICS_PORT, enable_ssl=false) }}
+
+ WSGIScriptAlias /metrics {{ RUCIO_PYTHON_PATH }}/web/rest/metrics.py process-group=rucio application-group=rucio
+</VirtualHost>
+{% endif %}
+
+{% if RUCIO_HEALTH_CHECK_PORT is defined %}
+Listen {{ RUCIO_HEALTH_CHECK_PORT }}
+<VirtualHost *:{{ RUCIO_HEALTH_CHECK_PORT }} >
+{{ common_virtual_host_config(port=RUCIO_HEALTH_CHECK_PORT, enable_ssl=RUCIO_ENABLE_SSL|default('False') == 'True', require_x509_auth=false) }}
+
+ WSGIScriptAlias /ping {{ RUCIO_PYTHON_PATH }}/web/rest/ping.py process-group=rucio application-group=rucio
+</VirtualHost>
+{% endif %}

--- a/overlays/dune/rucio/helm-rucio-server.yaml
+++ b/overlays/dune/rucio/helm-rucio-server.yaml
@@ -26,6 +26,7 @@ metadata:
 type: Opaque
 data:
   grid_site_enabled: "VHJ1ZQ=="
+  timeout: "MzAw"
 ---
 # Source: rucio-server/templates/service.yaml
 apiVersion: v1
@@ -127,10 +128,10 @@ spec:
           resources:
             limits:
               cpu: 1000m
-              memory: 3000Mi
+              memory: 4000Mi
             requests:
               cpu: 700m
-              memory: 3000Mi
+              memory: 4000Mi
           volumeMounts:
           - name: config
             mountPath: /opt/rucio/etc/conf.d/10_common.json
@@ -181,15 +182,20 @@ spec:
               path: /ping
               port: 444
               scheme: HTTPS
-            initialDelaySeconds: 10
+            initialDelaySeconds: 20
             periodSeconds: 120
-            timeoutSeconds: 60
+            timeoutSeconds: 180
           env:
             - name: RUCIO_HTTPD_GRID_SITE_ENABLED
               valueFrom:
                 secretKeyRef:
                   name: fnal-rucio-server.cfg
                   key: grid_site_enabled
+            - name: RUCIO_HTTPD_TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  name: fnal-rucio-server.cfg
+                  key: timeout
             - name: RUCIO_ENABLE_SSL
               value: "True"
             - name: RUCIO_HEALTH_CHECK_PORT

--- a/overlays/dune/rucio/kustomization.yaml
+++ b/overlays/dune/rucio/kustomization.yaml
@@ -14,6 +14,7 @@ patchesStrategicMerge:
 - patch-service.yaml
 - grid-certificates-patch.yaml
 - patch-webui.yaml
+- patch-server.yaml
 - patch-busybox.yaml
 
 configmapGenerator:
@@ -23,6 +24,9 @@ configmapGenerator:
 - name: webui-rucio-conf-j2
   files:
   - rucio.conf.j2=etc/rucio.conf.j2
+- name: server-rucio-conf-j2
+  files:
+  - rucio.conf.j2=etc/rucio-server.conf.j2
 
 secretGenerator:
 # Database Connection String

--- a/overlays/dune/rucio/patch-server.yaml
+++ b/overlays/dune/rucio/patch-server.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-rucio-server
+spec:
+  template:
+    spec:
+      serviceAccountName: useroot
+      volumes:
+        - name: rucio-conf-j2
+          configMap:
+            name: server-rucio-conf-j2
+      containers:
+        - name: rucio-server
+          volumeMounts:
+            - name: rucio-conf-j2
+              mountPath: /tmp/rucio.conf.j2
+              subPath: rucio.conf.j2

--- a/overlays/dune/rucio/values-rucio-server.yaml
+++ b/overlays/dune/rucio/values-rucio-server.yaml
@@ -76,15 +76,15 @@ minReadySeconds: 5
   #authServer: 5
   #traceServer: 5
 
-livenessProbe:
-  initialDelaySeconds: 10
-  periodSeconds: 120
-  timeoutSeconds: 60
-
 readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 120
   timeoutSeconds: 60
+
+livenessProbe:
+  initialDelaySeconds: 20 
+  periodSeconds: 120
+  timeoutSeconds: 180
 
 serverType: api
 
@@ -231,6 +231,7 @@ wsgi:
 ## values used to configure apache
 httpd_config:
   grid_site_enabled: "True"
+  timeout: "300"
   # mpm_mode: "event"
   # enable_status: "True"
   # legacy_dn: "False"
@@ -420,10 +421,10 @@ config:
 
 serverResources:
   limits:
-    memory: "3000Mi"
+    memory: "4000Mi"
     cpu: "1000m"
   requests:
-    memory: "3000Mi"
+    memory: "4000Mi"
     cpu: "700m"
 
 nodeSelector: {}


### PR DESCRIPTION
This was done to try to fix https://github.com/rucio/rucio/issues/7807

### Changes
* Increase rucio-server pod memory from 3GB to 4GB
* Custom httpd rucio.conf.j2 to include `listen-backlog=200 display-name=%{GROUP}` (for both dune and dune-int)
* Increase Timeout in httpd from 60s to 300s (5m)
* Increase liveness probe time