### PR TITLE
hypot: migrate from okd2 to 1, external secrets

### DIFF
--- a/overlays/hypot/external-secrets/kustomization.yaml
+++ b/overlays/hypot/external-secrets/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - rucio-external-secrets.yaml

--- a/overlays/hypot/external-secrets/rucio-external-secrets.yaml
+++ b/overlays/hypot/external-secrets/rucio-external-secrets.yaml
@@ -1,0 +1,245 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-db-connstr
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-server,rucio-daemons
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-db-connstr
+  data:
+  - secretKey: db-connstr.txt
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: db-connstr
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-server-hostcert
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-server
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-server-hostcert
+  data:
+  - secretKey: hostcert.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostcert
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-server-hostkey
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-server
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-server-hostkey
+  data:
+  - secretKey: hostkey.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostkey
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-hermes-cert
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-daemons,hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-hermes-cert
+  data:
+  - secretKey: hostcert.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostcert
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-hermes-key
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-daemons,hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-hermes-key
+  data:
+  - secretKey: hostkey.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostkey
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-fts-cert
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-daemons,fts-renewal
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-fts-cert
+  data:
+  - secretKey: usercert.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostcert
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-fts-key
+  namespace: rucio-hypot
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-fts-key
+  data:
+  - secretKey: new_userkey.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostkey
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ssl-secrets
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: messenger
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: ssl-secrets
+  data:
+  - secretKey: hostcert.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostcert
+  - secretKey: hostkey.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostkey
+  - secretKey: ca.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-cafile
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-hostcert
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-webui
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-hostcert
+  data:
+  - secretKey: hostcert.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostcert
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-hostkey
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-webui
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-hostkey
+  data:
+  - secretKey: hostkey.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-hostkey
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-cafile
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-webui
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-cafile
+  data:
+  - secretKey: ca.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: server-cafile
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fnal-idpsecrets
+  namespace: rucio-hypot
+  annotations:
+    rucioservice: rucio-server
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: fnal-idpsecrets
+  data:
+  - secretKey: ca.pem
+    remoteRef:
+      key: okd/okdprod1/rucio-hypot/rucio
+      property: idpsecrets

--- a/overlays/hypot/kustomization.yaml
+++ b/overlays/hypot/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
+- external-secrets
 - rucio/

--- a/overlays/hypot/rucio/helm-rucio-daemons.yaml
+++ b/overlays/hypot/rucio/helm-rucio-daemons.yaml
@@ -270,6 +270,7 @@ metadata:
 type: Opaque
 data:
   common.json: "ewogICJhdXRvbWF0aXgiOiB7CiAgICAiYWNjb3VudCI6ICJhdXRvbWF0aXgiLAogICAgImRhdGFzZXRfbGlmZXRpbWUiOiAzMCwKICAgICJyc2VzIjogIkRDQUNIRV9CSldISVRFX0VORCwgRENBQ0hFX0JKV0hJVEVfRU5EMiIsCiAgICAic2NvcGUiOiAiYXV0b21hdGl4IiwKICAgICJzZXRfbWV0YWRhdGEiOiAiVHJ1ZSIKICB9LAogICJjYWNoZSI6IHsKICAgICJ1cmwiOiAicnVjaW8tY2FjaGU6MTEyMTEiCiAgfSwKICAiY2xpZW50IjogewogICAgImFjY291bnQiOiAiYXV0b21hdGl4IiwKICAgICJhdXRoX2hvc3QiOiAiaHR0cHM6Ly9oeXBvdC1ydWNpby5mbmFsLmdvdiIsCiAgICAiYXV0aF90eXBlIjogIng1MDlfcHJveHkiLAogICAgImNhX2NlcnQiOiAiL2V0Yy9ncmlkLXNlY3VyaXR5L2NlcnRpZmljYXRlcyIsCiAgICAiY2xpZW50X3g1MDlfcHJveHkiOiAiL29wdC9wcm94eS94NTA5dXAiLAogICAgInByb3RvY29sX3N0YXRfcmV0cmllcyI6IDYsCiAgICAicmVxdWVzdF9yZXRyaWVzIjogMywKICAgICJydWNpb19ob3N0IjogImh0dHBzOi8vaHlwb3QtcnVjaW8uZm5hbC5nb3YiCiAgfSwKICAiY29udmV5b3IiOiB7CiAgICAiY2FjZXJ0IjogIi9vcHQvY2VydHMvY2EucGVtIiwKICAgICJ1c2VyY2VydCI6ICIvb3B0L3Byb3h5L3g1MDl1cCIKICB9LAogICJoZXJtZXMiOiB7CiAgICAic2VydmljZXNfbGlzdCI6ICJhY3RpdmVtcSIKICB9LAogICJtZXNzYWdpbmctY2FjaGUiOiB7CiAgICAiYWNjb3VudCI6ICJtZW1jYWNoZSIsCiAgICAiYnJva2VycyI6ICJydWNpby1jYWNoZSIsCiAgICAiZGVzdGluYXRpb24iOiAiL3RvcGljL3J1Y2lvLmV2ZW50cy5oeXBvdCIsCiAgICAicG9ydCI6ICI2MTEyMyIsCiAgICAidm9uYW1lIjogImZlcm1pbGFiIgogIH0sCiAgIm1lc3NhZ2luZy1oZXJtZXMiOiB7CiAgICAiYnJva2VyX3ZpcnR1YWxfaG9zdCI6ICIvIiwKICAgICJicm9rZXJzIjogImZuYWwtcnVjaW8tbWVzc2VuZ2VyIiwKICAgICJkZXN0aW5hdGlvbiI6ICIvdG9waWMvcnVjaW8uZXZlbnRzLmh5cG90IiwKICAgICJlbWFpbF9mcm9tIjogIlJ1Y2lvIFx1MDAzY2F0bGFzLWFkYy1kZG0tc3VwcG9ydEBjZXJuLmNoIiwKICAgICJlbWFpbF90ZXN0IjogIiIsCiAgICAibm9uc3NsX3BvcnQiOiAiNjE2MTMiLAogICAgInBhc3N3b3JkIjogImd1ZXN0IiwKICAgICJwb3J0IjogIjYxNjEzIiwKICAgICJzc2xfY2VydF9maWxlIjogIi9vcHQvcnVjaW8vY2VydHMvaG9zdGNlcnQucGVtIiwKICAgICJzc2xfa2V5X2ZpbGUiOiAiL29wdC9ydWNpby9rZXlzL2hvc3RrZXkucGVtIiwKICAgICJ1c2Vfc3NsIjogIkZhbHNlIiwKICAgICJ1c2VybmFtZSI6ICJndWVzdCIsCiAgICAidm9uYW1lIjogImh5cG90IgogIH0sCiAgIm1vbml0b3IiOiB7CiAgICAiZW5hYmxlX21ldHJpY3MiOiB0cnVlCiAgfSwKICAicG9saWN5IjogewogICAgInBhY2thZ2UiOiAiZmVybWlsYWIiCiAgfSwKICAidHJhbnNmZXJzIjogewogICAgIm11bHRpaG9wX3JzZV9leHByZXNzaW9uIjogIiIKICB9Cn0="
+
 ---
 # Source: rucio-daemons/templates/transmogrifier-deployment.yaml
 apiVersion: v1
@@ -313,6 +314,8 @@ roleRef:
   kind: ClusterRole
   name: edit
   apiGroup: rbac.authorization.k8s.io
+
+
 ---
 # Source: rucio-daemons/templates/service.yaml
 apiVersion: v1
@@ -334,6 +337,8 @@ spec:
   selector:
     app-group: rucio-daemons
     release: fnal
+
+
 ---
 # Source: rucio-daemons/templates/abacus-deployment.yaml
 apiVersion: apps/v1
@@ -598,6 +603,10 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
+
 ---
 # Source: rucio-daemons/templates/automatix-deployment.yaml
 apiVersion: apps/v1
@@ -697,6 +706,9 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+
+
+
 ---
 # Source: rucio-daemons/templates/conveyor-deployment.yaml
 apiVersion: apps/v1
@@ -1049,6 +1061,10 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
+
 ---
 # Source: rucio-daemons/templates/hermes-deployment.yaml
 apiVersion: apps/v1
@@ -1151,6 +1167,9 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
 ---
 # Source: rucio-daemons/templates/judge-deployment.yaml
 apiVersion: apps/v1
@@ -1503,6 +1522,10 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
+
 ---
 # Source: rucio-daemons/templates/minos-deployment.yaml
 apiVersion: apps/v1
@@ -1679,6 +1702,10 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+
+
+
+
 ---
 # Source: rucio-daemons/templates/necromancer-deployment.yaml
 apiVersion: apps/v1
@@ -1767,6 +1794,9 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+
+
+
 ---
 # Source: rucio-daemons/templates/reaper-deployment.yaml
 apiVersion: apps/v1
@@ -1864,6 +1894,9 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
 ---
 # Source: rucio-daemons/templates/replica-recoverer-deployment.yaml
 apiVersion: apps/v1
@@ -1952,6 +1985,9 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
 ---
 # Source: rucio-daemons/templates/transmogrifier-deployment.yaml
 apiVersion: apps/v1
@@ -2040,6 +2076,9 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
 ---
 # Source: rucio-daemons/templates/undertaker-deployment.yaml
 apiVersion: apps/v1
@@ -2128,6 +2167,9 @@ spec:
             requests:
               cpu: 700m
               memory: 200Mi
+
+
+
 ---
 # Source: rucio-daemons/templates/renew-fts-cronjob.yaml
 apiVersion: batch/v1
@@ -2285,3 +2327,5 @@ spec:
             - name: USERKEY_NAME
               value: new_userkey.pem
       restartPolicy: OnFailure
+
+

--- a/overlays/hypot/rucio/helm-rucio-server.yaml
+++ b/overlays/hypot/rucio/helm-rucio-server.yaml
@@ -26,6 +26,7 @@ metadata:
 type: Opaque
 data:
   grid_site_enabled: "VHJ1ZQ=="
+
 ---
 # Source: rucio-server/templates/service.yaml
 apiVersion: v1

--- a/overlays/hypot/rucio/helm-rucio-webui.yaml
+++ b/overlays/hypot/rucio/helm-rucio-webui.yaml
@@ -239,7 +239,7 @@ spec:
           resources:
             limits:
               cpu: 1000m
-              memory: 4Gi
+              memory: 6Gi
             requests:
               cpu: 100m
               memory: 128Mi

--- a/overlays/hypot/rucio/kustomization.yaml
+++ b/overlays/hypot/rucio/kustomization.yaml
@@ -18,25 +18,6 @@ patchesStrategicMerge:
 #- rucio-env-patch.yaml
 
 secretGenerator:
-# Database Connection String
-- name: fnal-db-connstr
-  files:
-  - db-connstr.txt=etc/.secrets/db-connstr
-
-# Server Secrets
-- name: fnal-server-hostcert
-  files:
-  - hostcert.pem=etc/.secrets/hostcert.pem
-- name: fnal-server-hostkey
-  files:
-  - hostkey.pem=etc/.secrets/hostkey.pem
-#- name: fnal-server-cafile
-#  files:
-#  - ca.pem=etc/.secrets/ca.pem
-- name: fnal-idpsecrets
-  files:
-  - idpsecrets.json=etc/.secrets/idpsecrets.json
-
 # The desired policy package implementation files
 - name: fnal-policy-package
   files:
@@ -46,19 +27,9 @@ secretGenerator:
 
 # Used by daemons
 - name: fnal-rucio-x509up
-  files:
-  - hostcert.pem=etc/.secrets/hostcert.pem
-  - hostkey.pem=etc/.secrets/hostkey.pem
-  options:
-    disableNameSuffixHash: true
-- name: fnal-hermes-cert
-  files:
-  - hostcert.pem=etc/.secrets/hostcert.pem
-  options:
-    disableNameSuffixHash: true
-- name: fnal-hermes-key
-  files:
-  - hostkey.pem=etc/.secrets/hostkey.pem
+  literals:
+  - hostcert.pem=
+  - hostkey.pem=
   options:
     disableNameSuffixHash: true
 - name: fnal-automatix-json
@@ -66,19 +37,6 @@ secretGenerator:
   - automatix.json=etc/automatix.json
   options:
     disableNameSuffixHash: true
-- name: fnal-fts-cert
-  files:
-  - usercert.pem=etc/.secrets/hostcert.pem
-- name: fnal-fts-key
-  files:
-  - new_userkey.pem=etc/.secrets/hostkey.pem
-
-# Messenger
-- name: ssl-secrets
-  files:
-  - hostcert.pem=etc/.secrets/hostcert.pem
-  - hostkey.pem=etc/.secrets/hostkey.pem
-  - ca.pem=etc/.secrets/ca.pem
 
 # VOMS Server File (used for getting VOMS proxies in the ftsRenewal Job)
 - name: fnal-vomses
@@ -92,31 +50,6 @@ secretGenerator:
 - name: fnal-rabbitmq-enabled-plugins
   files:
   - enabled_plugins=etc/enabled_plugins
-
-## ingress
-#- name: rucio-server.tls-secret
-#  files:
-#  - cert=etc/.secrets/hostcert.pem
-#  - key=etc/.secrets/hostkey.pem
-#
-# webui
-- name: fnal-hostcert
-  files:
-  - hostcert.pem=etc/.secrets/hostcert.pem
-- name: fnal-hostkey
-  files:
-  - hostkey.pem=etc/.secrets/hostkey.pem
-- name: fnal-cafile
-  files:
-  - ca.pem=etc/.secrets/ca.pem
-## lsst customization
-#- name: fnal-lsst-schema-file
-#  files:
-#  - lsst.py=etc/lsst.py
-#  options:
-#    disableNameSuffixHash: true
-## automatix input
-#
 
 # Custom HTTPD config options for Fermilab
 - name: fnal-httpd-custom-config

--- a/overlays/hypot/rucio/patch-service.yaml
+++ b/overlays/hypot/rucio/patch-service.yaml
@@ -3,18 +3,18 @@ kind: Service
 metadata:
   name: fnal-rucio-server
 spec:
-  externalIPs: [ 131.225.218.217 ]
+  externalIPs: [ 131.225.218.177 ]
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: fnal-rucio-messenger
 spec:
-  externalIPs: [ 131.225.218.214 ]
+  externalIPs: [ 131.225.218.174 ]
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: fnal-rucio-webui
 spec:
-  externalIPs: [ 131.225.218.215 ]
+  externalIPs: [ 131.225.218.175 ]

--- a/overlays/hypot/rucio/values-rucio-webui.yaml
+++ b/overlays/hypot/rucio/values-rucio-webui.yaml
@@ -140,7 +140,7 @@ persistentVolumes: {}
 resources:
   limits:
     cpu: 1000m
-    memory: 4Gi
+    memory: 6Gi
   requests:
     cpu: 100m
     memory: 128Mi


### PR DESCRIPTION
Updated manifests to migrate hypot from okd2 to okd1
Also use external secrets